### PR TITLE
Add enum validation for KPIs and Appraisals

### DIFF
--- a/constants/kpi.go
+++ b/constants/kpi.go
@@ -1,0 +1,22 @@
+package constants
+
+// KPI Types
+const (
+	FEEDBACK_KPI_TYPE      = "Feedback"
+	OBSERVATORY_KPI_TYPE   = "Observatory"
+	MEASURED_KPI_TYPE      = "Measured"
+	QUESTIONNAIRE_KPI_TYPE = "Questionnaire"
+)
+
+// Basic KPI Types
+const (
+	SINGLE_KPI_TYPE = "Single"
+	MULTI_KPI_TYPE  = "Multi"
+)
+
+// Assign Types
+const (
+	ASSIGN_TYPE_ROLE       = "Role"
+	ASSIGN_TYPE_TEAM       = "Team"
+	ASSIGN_TYPE_INDIVIDUAL = "Individual"
+)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/gin-contrib/cors v1.4.0
 	github.com/gin-gonic/gin v1.8.2
+	github.com/go-playground/validator/v10 v10.11.2
 	github.com/joho/godotenv v1.5.1
 	github.com/lib/pq v1.10.7
 	github.com/sirupsen/logrus v1.9.0
@@ -16,7 +17,6 @@ require (
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
-	github.com/go-playground/validator/v10 v10.11.2 // indirect
 	github.com/goccy/go-json v0.10.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ func main() {
 
 	// Initializing custom validator
 	if v, ok := binding.Validator.Engine().(*validator.Validate); ok {
-		v.RegisterValidation("enum", models.ValidateEnum)
+		_ = v.RegisterValidation("enum", models.ValidateEnum)
 	}
 
 	// Initializing logger

--- a/main.go
+++ b/main.go
@@ -3,15 +3,23 @@ package main
 import (
 	"os"
 
+	"github.com/gin-gonic/gin/binding"
+	"github.com/go-playground/validator/v10"
 	"github.com/joho/godotenv"
 	"github.com/mrehanabbasi/appraisal-system-backend/database"
 	"github.com/mrehanabbasi/appraisal-system-backend/logger"
+	"github.com/mrehanabbasi/appraisal-system-backend/models"
 	"github.com/mrehanabbasi/appraisal-system-backend/routes"
 )
 
 func main() {
 	// Load environment variables from .env file
 	_ = godotenv.Load(".env")
+
+	// Initializing custom validator
+	if v, ok := binding.Validator.Engine().(*validator.Validate); ok {
+		v.RegisterValidation("enum", models.ValidateEnum)
+	}
 
 	// Initializing logger
 	logger.TextLogInit()

--- a/models/common.go
+++ b/models/common.go
@@ -3,6 +3,7 @@ package models
 import (
 	"time"
 
+	"github.com/go-playground/validator/v10"
 	"gorm.io/gorm"
 )
 
@@ -11,4 +12,13 @@ type CommonModel struct {
 	CreatedAt time.Time      `gorm:"<-:create" json:"-"`
 	UpdatedAt time.Time      `json:"-"`
 	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
+}
+
+type Enum interface {
+	IsValid() bool
+}
+
+func ValidateEnum(fl validator.FieldLevel) bool {
+	value := fl.Field().Interface().(Enum)
+	return value.IsValid()
 }

--- a/models/kpi.go
+++ b/models/kpi.go
@@ -2,18 +2,22 @@ package models
 
 import (
 	"github.com/lib/pq"
+	"github.com/mrehanabbasi/appraisal-system-backend/constants"
 )
+
+type BasicKpiType string
+type AssignTypeStr string
 
 type KpiType struct {
 	CommonModel
-	KpiType      string `gorm:"not null;unique" json:"kpi_type"`
-	BasicKpiType string `gorm:"not null" json:"basic_kpi_type"`
+	KpiType      string       `gorm:"not null;unique" json:"kpi_type"`
+	BasicKpiType BasicKpiType `gorm:"not null" json:"basic_kpi_type" binding:"enum"`
 }
 
 type AssignType struct {
 	CommonModel
-	AssignTypeId uint64 `gorm:"not null;unique" json:"assign_type_id"`
-	AssignType   string `gorm:"not null;unique" json:"assign_type"`
+	AssignTypeId uint64        `gorm:"not null;unique" json:"assign_type_id"`
+	AssignType   AssignTypeStr `gorm:"not null;unique" json:"assign_type" binding:"enum"`
 }
 
 type Kpi struct {
@@ -35,4 +39,22 @@ type MultiStatementKpiData struct {
 	Statement     string `gorm:"not null" json:"statement"`
 	CorrectAnswer string `gorm:"not null" json:"correct_answer"`
 	Weightage     uint64 `gorm:"not null" json:"weightage"`
+}
+
+func (b BasicKpiType) IsValid() bool {
+	switch b {
+	case constants.SINGLE_KPI_TYPE, constants.MULTI_KPI_TYPE:
+		return true
+	}
+
+	return false
+}
+
+func (a AssignTypeStr) IsValid() bool {
+	switch a {
+	case constants.ASSIGN_TYPE_ROLE, constants.ASSIGN_TYPE_TEAM, constants.ASSIGN_TYPE_INDIVIDUAL:
+		return true
+	}
+
+	return false
 }

--- a/service/kpi.go
+++ b/service/kpi.go
@@ -7,29 +7,13 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"github.com/mrehanabbasi/appraisal-system-backend/constants"
 	"github.com/mrehanabbasi/appraisal-system-backend/controller"
 	"github.com/mrehanabbasi/appraisal-system-backend/database"
 	log "github.com/mrehanabbasi/appraisal-system-backend/logger"
 	"github.com/mrehanabbasi/appraisal-system-backend/models"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
-)
-
-const (
-	FEEDBACK_KPI_TYPE      = "Feedback"
-	OBSERVATORY_KPI_TYPE   = "Observatory"
-	MEASURED_KPI_TYPE      = "Measured"
-	QUESTIONNAIRE_KPI_TYPE = "Questionnaire"
-)
-const (
-	SINGLE_KPI_TYPE = "Single"
-	MULTI_KPI_TYPE  = "Multi"
-)
-
-const (
-	ASSIGN_TYPE_ROLE       = "Role"
-	ASSIGN_TYPE_TEAM       = "Team"
-	ASSIGN_TYPE_INDIVIDUAL = "Individual"
 )
 
 type KPIService struct {
@@ -61,10 +45,10 @@ func NewKPIService() *KPIService {
 func populateKpiTypeTable(db *gorm.DB) error {
 	// TODO: Delete this table population and get KPI types from /kpi_types endpoint
 	kpiTypes := []string{
-		FEEDBACK_KPI_TYPE,
-		OBSERVATORY_KPI_TYPE,
-		MEASURED_KPI_TYPE,
-		QUESTIONNAIRE_KPI_TYPE,
+		constants.FEEDBACK_KPI_TYPE,
+		constants.OBSERVATORY_KPI_TYPE,
+		constants.MEASURED_KPI_TYPE,
+		constants.QUESTIONNAIRE_KPI_TYPE,
 	}
 
 	kpiTypesSlice := make([]models.KpiType, len(kpiTypes))
@@ -74,9 +58,9 @@ func populateKpiTypeTable(db *gorm.DB) error {
 			KpiType: v,
 		}
 		if k == 0 || k == 1 { // Feedback and Observatory will be 'Single'
-			newKpiType.BasicKpiType = SINGLE_KPI_TYPE
+			newKpiType.BasicKpiType = constants.SINGLE_KPI_TYPE
 		} else if k == 2 || k == 3 { // Measured and Questionnaire will be 'Multi'
-			newKpiType.BasicKpiType = MULTI_KPI_TYPE
+			newKpiType.BasicKpiType = constants.MULTI_KPI_TYPE
 		}
 
 		kpiTypesSlice[k] = newKpiType
@@ -93,9 +77,9 @@ func populateKpiTypeTable(db *gorm.DB) error {
 
 func populateAssignTypeTable(db *gorm.DB) error {
 	assignTypes := []string{
-		ASSIGN_TYPE_ROLE,
-		ASSIGN_TYPE_TEAM,
-		ASSIGN_TYPE_INDIVIDUAL,
+		constants.ASSIGN_TYPE_ROLE,
+		constants.ASSIGN_TYPE_TEAM,
+		constants.ASSIGN_TYPE_INDIVIDUAL,
 	}
 
 	// Make assign type ID as 0 = Role, 1 = Team and 2 = Individual
@@ -103,7 +87,7 @@ func populateAssignTypeTable(db *gorm.DB) error {
 	for i, a := range assignTypes {
 		newAssignType := models.AssignType{
 			AssignTypeId: uint64(i),
-			AssignType:   a,
+			AssignType:   models.AssignTypeStr(a),
 		}
 		assignTypesSlice[i] = newAssignType
 	}
@@ -146,7 +130,7 @@ func (s *KPIService) CreateKPI(c *gin.Context) {
 	}
 
 	switch kpiType.BasicKpiType {
-	case SINGLE_KPI_TYPE:
+	case constants.SINGLE_KPI_TYPE:
 		if kpi.Statement == "" {
 			log.Error("statement is nil in the request")
 			c.JSON(http.StatusBadRequest, gin.H{"error": "statement is nil"})
@@ -154,7 +138,7 @@ func (s *KPIService) CreateKPI(c *gin.Context) {
 		}
 
 		kpi.Statements = nil
-	case MULTI_KPI_TYPE:
+	case constants.MULTI_KPI_TYPE:
 		if len(kpi.Statements) == 0 {
 			log.Error("statements are nil in the request")
 			c.JSON(http.StatusBadRequest, gin.H{"error": "statements field is nil"})
@@ -210,7 +194,7 @@ func (s *KPIService) UpdateKPI(c *gin.Context) {
 	}
 
 	switch kpiType.BasicKpiType {
-	case SINGLE_KPI_TYPE:
+	case constants.SINGLE_KPI_TYPE:
 		if kpi.Statement == "" {
 			log.Error("statement is nil in the request")
 			c.JSON(http.StatusBadRequest, gin.H{"error": "statement is nil"})
@@ -218,7 +202,7 @@ func (s *KPIService) UpdateKPI(c *gin.Context) {
 		}
 
 		kpi.Statements = nil
-	case MULTI_KPI_TYPE:
+	case constants.MULTI_KPI_TYPE:
 		if len(kpi.Statements) == 0 {
 			log.Error("statements are nil in the request")
 			c.JSON(http.StatusBadRequest, gin.H{"error": "statements field is nil"})


### PR DESCRIPTION
This PR will add enum valudation for fields like `AssignType` and `BasicKpiType`. It also separates constants in their own package.